### PR TITLE
Only replace params.playerid by default if it is not set.

### DIFF
--- a/lib/kodi-rpc-player.js
+++ b/lib/kodi-rpc-player.js
@@ -4,6 +4,11 @@
     };
 
     var defaultplayer = 1;
+    var set_default_playerid_if_none_set = function (params) {
+        if (typeof params.playerid == 'undefined') {
+            params.playerid = defaultplayer;
+        }
+    }
 
     KodiPlayer.prototype.getActivePlayers = function() {
         return this.delegate.rpc('Player.GetActivePlayers').then(function(r) {
@@ -14,7 +19,7 @@
     KodiPlayer.prototype.getProperties = function(params) {
         params = params || {};
         params.properties = params.properties || ["time", "percentage", "totaltime", "speed"];
-        params.playerid = params.playerid ||  defaultplayer;
+        set_default_playerid_if_none_set(params);
         return this.delegate.rpc('Player.GetProperties', JSON.stringify(params)).then(function(r) {
             return r.result;
         });
@@ -27,7 +32,7 @@
             };
         }
         params = params || {};
-        params.playerid = params.playerid || defaultplayer;
+        set_default_playerid_if_none_set(params);
         return this.delegate.rpc('Player.GetItem', JSON.stringify(params)).then(function(r) {
             return r.result;
         });
@@ -41,7 +46,7 @@
             };
         }
         params = params || {};
-        params.playerid = params.playerid || defaultplayer;
+        set_default_playerid_if_none_set(params);
         player.to = player.to || "next";
         return this.delegate.rpc('Player.GoTo', JSON.stringify(params)).then(function(r) {
             return r.result;
@@ -56,7 +61,7 @@
             };
         }
         params = params || {};
-        params.playerid = params.playerid || defaultplayer;
+        set_default_playerid_if_none_set(params);
         params.direction = params.direction || "left";
         return this.delegate.rpc('Player.Move', JSON.stringify(params)).then(function(r) {
             return r.result;
@@ -85,7 +90,7 @@
         params = params || {};
         params.play = params.play || "toggle"; //default
 
-        params.playerid = params.playerid ||  defaultplayer;
+        set_default_playerid_if_none_set(params);
         return this.delegate.rpc('Player.PlayPause', JSON.stringify(params)).then(function(r) {
             return r.result;
         });
@@ -103,7 +108,7 @@
         }
         params = params || {};
         params.value = params.value || "clockwise"; //default
-        params.playerid = params.playerid || defaultplayer;
+        set_default_playerid_if_none_set(params);
         return this.delegate.rpc('Player.Rotate', JSON.stringify(params)).then(function(r) {
             return r.result;
         });
@@ -121,7 +126,7 @@
         }
         params = params || {};
         params.value = params.value || "smallforward"; //default
-        params.playerid = params.playerid || defaultplayer;
+        set_default_playerid_if_none_set(params);
         return this.delegate.rpc('Player.Seek', JSON.stringify(params)).then(function(r) {
             return r.result;
         });
@@ -134,7 +139,7 @@
             };
         }
         params = params || {};
-        params.playerid = params.playerid || defaultplayer;
+        set_default_playerid_if_none_set(params);
         params.stream = params.stream || "next"; //default
         return this.delegate.rpc('Player.SetAudioStream', JSON.stringify(params)).then(function(r) {
             return r.result;
@@ -152,7 +157,7 @@
             };
         }
         params = params || {};
-        params.playerid = params.playerid || defaultplayer;
+        set_default_playerid_if_none_set(params);
         params.partymode = params.partymode || "toggle"; //default
         return this.delegate.rpc('Player.SetPartymode', JSON.stringify(params)).then(function(r) {
             return r.result;
@@ -166,7 +171,7 @@
             };
         }
         params = params || {};
-        params.playerid = params.playerid || defaultplayer;
+        set_default_playerid_if_none_set(params);
         params.repeat = params.repeat || "cycle"; //default
         return this.delegate.rpc('Player.SetRepeat', JSON.stringify(params)).then(function(r) {
             return r.result;
@@ -184,7 +189,7 @@
             };
         }
         params = params || {};
-        params.playerid = params.playerid || defaultplayer;
+        set_default_playerid_if_none_set(params);
         params.shuffle = params.shuffle || "toggle";
         return this.delegate.rpc('Player.SetShuffle', JSON.stringify(params)).then(function(r) {
             return r.result;
@@ -198,7 +203,7 @@
             };
         }
         params = params || {};
-        params.playerid = params.playerid || defaultplayer;
+        set_default_playerid_if_none_set(params);
         params.speed = params.speed || 1; //default
         return this.delegate.rpc('Player.SetSpeed', JSON.stringify(params)).then(function(r) {
             return r.result;
@@ -220,7 +225,7 @@
             };
         }
         params = params || {};
-        params.playerid = params.playerid || defaultplayer;
+        set_default_playerid_if_none_set(params);
         params.subtitle = params.subtitle || "next"; //default
         return this.delegate.rpc('Player.SetSubtitle', JSON.stringify(params)).then(function(r) {
             return r.result;
@@ -234,7 +239,7 @@
             };
         }
         params = params || {};
-        params.playerid = params.playerid || defaultplayer;
+        set_default_playerid_if_none_set(params);
         return this.delegate.rpc('Player.Stop', JSON.stringify(params)).then(function(r) {
             return r.result;
         });
@@ -252,7 +257,7 @@
         }
         params = params || {};
         params.zoom = params.zoom || "in"; //default
-        params.playerid = params.playerid || defaultplayer;
+        set_default_playerid_if_none_set(params);
         return this.delegate.rpc('Player.Zoom', JSON.stringify(params)).then(function(r) {
             return r.result;
         });


### PR DESCRIPTION
Hi,
first of all, thanks a lot for providing this library :)

I ran into a small problem when calling `kodi.player.getProperties({playerid: 0})`:
The `playerid` gets replaced by the default-playerid.

This PR should fix this.

Best regards
Ben